### PR TITLE
Add WebSocket demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 __pycache__/
 *.py[cod]
 venv/
+node_modules/
+package-lock.json
 
 # macOS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project is a standalone front‑end demo of an options trading dashboard. I
 - **Options Heatmap.** Lists unusual options activity with metrics like put/call ratio.
 - **Custom Filters & Market Timing.** Lets the user pick trading strategies and includes a countdown to the market open.
 - Toast notifications and loading skeletons give realtime feedback during updates.
+- **WebSocket streaming.** Connects to a local server for live options data updates.
 
 All demo data is stored locally in [`app.js`](app.js) and the additional JSON/CSV files included in the repository.
 
@@ -23,8 +24,9 @@ All demo data is stored locally in [`app.js`](app.js) and the additional JSON/CS
 
 1. Clone the repository.
 2. Run `./install.sh` to create a Python virtual environment.
-3. Start the dashboard with `./install.sh --start` or manually run `source venv/bin/activate && python3 -m http.server`.
-4. Open `http://localhost:8000/index.html` in your browser.
+3. Install Node dependencies with `npm install` and start the WebSocket server using `npm start`.
+4. Start the dashboard with `./install.sh --start` or manually run `source venv/bin/activate && python3 -m http.server`.
+5. Open `http://localhost:8000/index.html` in your browser.
 
 You can also open `index.html` directly without a server, but some browsers block certain features when loaded from the filesystem.
 
@@ -35,4 +37,4 @@ You can also open `index.html` directly without a server, but some browsers bloc
 - `app.js` &mdash; dashboard logic and sample data generation.
 - `market_dashboard_data.json`, `historical_market_data.csv`, `investment_insights.json` &mdash; additional example datasets.
 
-The project is intended for educational or prototyping purposes and is not connected to live market data.
+The project ships with a lightweight WebSocket server that streams mock data for development. It is intended for educational or prototyping purposes and is not connected to live market feeds.

--- a/app.js
+++ b/app.js
@@ -8,6 +8,8 @@ class PremarketDashboard {
         this.lastSyncTime = null;
         this.retryAttempts = 3;
         this.currentRetryCount = 0;
+        this.ws = null;
+        this.reconnectTimeout = null;
         
         // Sample data from the provided JSON
         this.sampleData = {
@@ -200,6 +202,7 @@ class PremarketDashboard {
         this.loadInitialData();
         this.startMarketCountdown();
         this.startAutoRefresh();
+        this.connectWebSocket();
         
         // Show initial status
         this.updateConnectionStatus('connected');
@@ -892,11 +895,59 @@ class PremarketDashboard {
 
     formatTime(timestamp) {
         const date = new Date(timestamp);
-        return date.toLocaleTimeString('en-US', { 
-            hour: '2-digit', 
+        return date.toLocaleTimeString('en-US', {
+            hour: '2-digit',
             minute: '2-digit',
-            hour12: true 
+            hour12: true
         });
+    }
+
+    connectWebSocket() {
+        const url = 'ws://localhost:8081';
+        if (this.ws) {
+            this.ws.close();
+        }
+        this.ws = new WebSocket(url);
+
+        this.ws.addEventListener('open', () => {
+            this.updateConnectionStatus('connected');
+            this.showToast('success', 'WebSocket', 'Streaming live data');
+        });
+
+        this.ws.addEventListener('message', (event) => {
+            try {
+                const data = JSON.parse(event.data);
+                this.handleWebSocketData(data);
+            } catch (err) {
+                console.error('Invalid WS message', err);
+            }
+        });
+
+        this.ws.addEventListener('close', () => {
+            this.updateConnectionStatus('error');
+            this.showToast('warning', 'WebSocket', 'Reconnecting...');
+            if (!this.reconnectTimeout) {
+                this.reconnectTimeout = setTimeout(() => {
+                    this.reconnectTimeout = null;
+                    this.connectWebSocket();
+                }, 3000);
+            }
+        });
+
+        this.ws.addEventListener('error', () => {
+            this.updateConnectionStatus('error');
+        });
+    }
+
+    handleWebSocketData(data) {
+        if (data.module === 'options_heatmap' && data.data) {
+            this.sampleData.options_flow.put_call_ratio = parseFloat(data.data.put_call_ratio);
+            this.sampleData.options_flow.dark_pool_activity = data.data.dark_pool_activity;
+            if (Array.isArray(data.data.unusual_activity)) {
+                this.sampleData.options_flow.unusual_activity = data.data.unusual_activity;
+            }
+            this.loadOptionsData();
+        }
     }
 
     getIVRankClass(rank) {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "premarket-options-dashboard",
+  "version": "1.0.0",
+  "description": "This project is a standalone front‑end demo of an options trading dashboard. It renders several modules using sample data and does not require a backend service.",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node realtime_server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "ws": "^8.18.3"
+  }
+}

--- a/realtime_server.js
+++ b/realtime_server.js
@@ -1,0 +1,41 @@
+const WebSocket = require('ws');
+
+const wss = new WebSocket.Server({ port: 8081 });
+
+function randomActivity() {
+  return {
+    symbol: 'AAPL',
+    type: Math.random() > 0.5 ? 'Call' : 'Put',
+    strike: (190 + Math.floor(Math.random() * 20)) * 1,
+    expiry: '2025-07-18',
+    volume: Math.floor(Math.random() * 20000 + 1000),
+    oi_change: Math.floor(Math.random() * 5000)
+  };
+}
+
+function buildMessage() {
+  return {
+    module: 'options_heatmap',
+    data: {
+      put_call_ratio: (0.5 + Math.random()).toFixed(2),
+      dark_pool_activity: Math.random() > 0.5 ? 'Above Average' : 'Below Average',
+      unusual_activity: [randomActivity()]
+    }
+  };
+}
+
+wss.on('connection', ws => {
+  console.log('WebSocket client connected');
+  const sendUpdate = () => {
+    const msg = buildMessage();
+    ws.send(JSON.stringify(msg));
+  };
+  const interval = setInterval(sendUpdate, 5000);
+  sendUpdate();
+
+  ws.on('close', () => {
+    clearInterval(interval);
+  });
+});
+
+console.log('Real-time server running on ws://localhost:8081');


### PR DESCRIPTION
## Summary
- add npm project and realtime WebSocket server
- ignore node-related artifacts
- update README with instructions for starting websocket server
- hook up client websocket in app.js for live option heatmap updates

## Testing
- `npm install`
- `node realtime_server.js &` (background)
- `kill $!`

------
https://chatgpt.com/codex/tasks/task_e_686b403ff21c8332a9fc5f774dce55e0